### PR TITLE
Guide READMEs now reference appropriate providers

### DIFF
--- a/docs/guides/aks/README.md
+++ b/docs/guides/aks/README.md
@@ -1,4 +1,4 @@
 # User Guides
 
-- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in aks
-- [Credentials](credentials/README.md) shows how to create, edit and update credential for aks
+- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in AKS.
+- [Credentials](credentials/README.md) shows how to create, edit and update credential for AKS.

--- a/docs/guides/aws/README.md
+++ b/docs/guides/aws/README.md
@@ -1,4 +1,4 @@
 # User Guides
 
-- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in aks
-- [Credentials](credentials/README.md) shows how to create, edit and update credential for aks
+- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in AWS.
+- [Credentials](credentials/README.md) shows how to create, edit and update credential for AWS.

--- a/docs/guides/azure/README.md
+++ b/docs/guides/azure/README.md
@@ -1,4 +1,4 @@
 # User Guides
 
-- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in aks
-- [Credentials](credentials/README.md) shows how to create, edit and update credential for aks
+- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in Azure.
+- [Credentials](credentials/README.md) shows how to create, edit and update credential for Azure.

--- a/docs/guides/digitalocean/README.md
+++ b/docs/guides/digitalocean/README.md
@@ -1,4 +1,4 @@
 # User Guides
 
-- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in aks
-- [Credentials](credentials/README.md) shows how to create, edit and update credential for aks
+- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in DigitalOcean.
+- [Credentials](credentials/README.md) shows how to create, edit and update credential for DigitalOcean.

--- a/docs/guides/eks/README.md
+++ b/docs/guides/eks/README.md
@@ -1,4 +1,4 @@
 # User Guides
 
-- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in aks
-- [Credentials](credentials/README.md) shows how to create, edit and update credential for aks
+- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in EKS.
+- [Credentials](credentials/README.md) shows how to create, edit and update credential for EKS.

--- a/docs/guides/gce/README.md
+++ b/docs/guides/gce/README.md
@@ -1,4 +1,4 @@
 # User Guides
 
-- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in aks
-- [Credentials](credentials/README.md) shows how to create, edit and update credential for aks
+- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in GCE.
+- [Credentials](credentials/README.md) shows how to create, edit and update credential for GCE.

--- a/docs/guides/gke/README.md
+++ b/docs/guides/gke/README.md
@@ -1,4 +1,4 @@
 # User Guides
 
-- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in aks
-- [Credentials](credentials/README.md) shows how to create, edit and update credential for aks
+- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in GKE.
+- [Credentials](credentials/README.md) shows how to create, edit and update credential for GKE.

--- a/docs/guides/linode/README.md
+++ b/docs/guides/linode/README.md
@@ -1,4 +1,4 @@
 # User Guides
 
-- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in aks
-- [Credentials](credentials/README.md) shows how to create, edit and update credential for aks
+- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in Linode.
+- [Credentials](credentials/README.md) shows how to create, edit and update credential for Linode.

--- a/docs/guides/packet/README.md
+++ b/docs/guides/packet/README.md
@@ -1,4 +1,4 @@
 # User Guides
 
-- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in aks
-- [Credentials](credentials/README.md) shows how to create, edit and update credential for aks
+- [Quickstart](quickstart/README.md) shows how you can create, upgrade and delete a cluster in Packet.
+- [Credentials](credentials/README.md) shows how to create, edit and update credential for Packet.


### PR DESCRIPTION
- The README.md for each cloud provider guide erroneously referred to
AKS.

Signed-off-by: Sam Leavens <rbwsam@gmail.com>